### PR TITLE
Remove TryAddTupleToOutputMatchingTableDefinitions

### DIFF
--- a/src/WixToolset.Extensibility/Services/IWindowsInstallerBackendHelper.cs
+++ b/src/WixToolset.Extensibility/Services/IWindowsInstallerBackendHelper.cs
@@ -12,7 +12,5 @@ namespace WixToolset.Extensibility.Services
     public interface IWindowsInstallerBackendHelper
     {
         bool TryAddTupleToOutputMatchingTableDefinitions(IntermediateTuple tuple, WindowsInstallerData output, IEnumerable<TableDefinition> tableDefinitions);
-
-        bool TryAddTupleToOutputMatchingTableDefinitions(IntermediateTuple tuple, WindowsInstallerData output, IEnumerable<TableDefinition> tableDefinitions, bool columnZeroIsId);
     }
 }


### PR DESCRIPTION
overload for `columnZeroIsId` since that is now in the table definition.