### PR TITLE
Use extension methods instead of a custom interface for IServiceProvider

### DIFF
--- a/src/WixToolset.Extensibility/Data/IBindContext.cs
+++ b/src/WixToolset.Extensibility/Data/IBindContext.cs
@@ -2,50 +2,109 @@
 
 namespace WixToolset.Extensibility.Data
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading;
     using WixToolset.Data;
-    using WixToolset.Extensibility.Services;
 
-#pragma warning disable 1591 // TODO: add documentation
+    /// <summary>
+    /// Bind context.
+    /// </summary>
     public interface IBindContext
     {
-        IWixToolsetServiceProvider ServiceProvider { get; }
+        /// <summary>
+        /// Service provider.
+        /// </summary>
+        IServiceProvider ServiceProvider { get; }
 
+        /// <summary>
+        /// Counnt of threads to use in cabbing.
+        /// </summary>
         int CabbingThreadCount { get; set; }
 
+        /// <summary>
+        /// Cabinet cache path.
+        /// </summary>
         string CabCachePath { get; set; }
 
+        /// <summary>
+        /// Codepage for result.
+        /// </summary>
         int Codepage { get; set; }
 
+        /// <summary>
+        /// Default compression level.
+        /// </summary>
         CompressionLevel? DefaultCompressionLevel { get; set; }
 
+        /// <summary>
+        /// Delayed fields that need to be resolved again.
+        /// </summary>
         IEnumerable<IDelayedField> DelayedFields { get; set; }
 
+        /// <summary>
+        /// Embedded files to extract.
+        /// </summary>
         IEnumerable<IExpectedExtractFile> ExpectedEmbeddedFiles { get; set; }
 
+        /// <summary>
+        /// Binder extensions.
+        /// </summary>
         IEnumerable<IBinderExtension> Extensions { get; set; }
 
+        /// <summary>
+        /// File system extensions.
+        /// </summary>
         IEnumerable<IFileSystemExtension> FileSystemExtensions { get; set; }
 
+        /// <summary>
+        /// Set of ICEs to execute.
+        /// </summary>
         IEnumerable<string> Ices { get; set; }
 
+        /// <summary>
+        /// Intermedaite folder.
+        /// </summary>
         string IntermediateFolder { get; set; }
 
+        /// <summary>
+        /// Intermediate representation to bind.
+        /// </summary>
         Intermediate IntermediateRepresentation { get; set; }
 
+        /// <summary>
+        /// Output path to bind to.
+        /// </summary>
         string OutputPath { get; set; }
 
+        /// <summary>
+        /// Type of PDB to create.
+        /// </summary>
         PdbType PdbType { get; set; }
 
+        /// <summary>
+        /// Output path for PDB.
+        /// </summary>
         string PdbPath { get; set; }
 
+        /// <summary>
+        /// Set of ICEs to skip.
+        /// </summary>
         IEnumerable<string> SuppressIces { get; set; }
 
+        /// <summary>
+        /// Skip all ICEs.
+        /// </summary>
         bool SuppressValidation { get; set; }
 
+        /// <summary>
+        /// Skip creation of output.
+        /// </summary>
         bool SuppressLayout { get; set; }
 
+        /// <summary>
+        /// Cancellation token.
+        /// </summary>
         CancellationToken CancellationToken { get; set; }
     }
 }

--- a/src/WixToolset.Extensibility/Data/ICommandLineContext.cs
+++ b/src/WixToolset.Extensibility/Data/ICommandLineContext.cs
@@ -8,7 +8,7 @@ namespace WixToolset.Extensibility.Data
 #pragma warning disable 1591 // TODO: add documentation
     public interface ICommandLineContext
     {
-        IWixToolsetServiceProvider ServiceProvider { get; }
+        IServiceProvider ServiceProvider { get; }
 
         IExtensionManager ExtensionManager { get; set; }
 

--- a/src/WixToolset.Extensibility/Data/ICompileContext.cs
+++ b/src/WixToolset.Extensibility/Data/ICompileContext.cs
@@ -2,11 +2,11 @@
 
 namespace WixToolset.Extensibility.Data
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading;
     using System.Xml.Linq;
     using WixToolset.Data;
-    using WixToolset.Extensibility.Services;
 
     /// <summary>
     /// Context provided to the compiler.
@@ -16,7 +16,7 @@ namespace WixToolset.Extensibility.Data
         /// <summary>
         /// Service provider made available to the compiler and its extensions.
         /// </summary>
-        IWixToolsetServiceProvider ServiceProvider { get; }
+        IServiceProvider ServiceProvider { get; }
 
         /// <summary>
         /// Unique identifier for the compilation.

--- a/src/WixToolset.Extensibility/Data/IDecompileContext.cs
+++ b/src/WixToolset.Extensibility/Data/IDecompileContext.cs
@@ -10,7 +10,7 @@ namespace WixToolset.Extensibility.Data
 #pragma warning disable 1591 // TODO: add documentation
     public interface IDecompileContext
     {
-        IWixToolsetServiceProvider ServiceProvider { get; }
+        IServiceProvider ServiceProvider { get; }
 
         string DecompilePath { get; set; }
 

--- a/src/WixToolset.Extensibility/Data/IFileSystemContext.cs
+++ b/src/WixToolset.Extensibility/Data/IFileSystemContext.cs
@@ -9,7 +9,7 @@ namespace WixToolset.Extensibility.Data
 #pragma warning disable 1591 // TODO: add documentation
     public interface IFileSystemContext
     {
-        IWixToolsetServiceProvider ServiceProvider { get; }
+        IServiceProvider ServiceProvider { get; }
 
         string CabCachePath { get; set; }
 

--- a/src/WixToolset.Extensibility/Data/IInscribeContext.cs
+++ b/src/WixToolset.Extensibility/Data/IInscribeContext.cs
@@ -8,7 +8,7 @@ namespace WixToolset.Extensibility.Data
 #pragma warning disable 1591 // TODO: add documentation
     public interface IInscribeContext
     {
-        IWixToolsetServiceProvider ServiceProvider { get; }
+        IServiceProvider ServiceProvider { get; }
 
         string InputFilePath { get; set; }
 

--- a/src/WixToolset.Extensibility/Data/ILayoutContext.cs
+++ b/src/WixToolset.Extensibility/Data/ILayoutContext.cs
@@ -2,14 +2,14 @@
 
 namespace WixToolset.Extensibility.Data
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading;
-    using WixToolset.Extensibility.Services;
 
 #pragma warning disable 1591 // TODO: add documentation
     public interface ILayoutContext
     {
-        IWixToolsetServiceProvider ServiceProvider { get; }
+        IServiceProvider ServiceProvider { get; }
 
         IEnumerable<ILayoutExtension> Extensions { get; set; }
 

--- a/src/WixToolset.Extensibility/Data/ILibraryContext.cs
+++ b/src/WixToolset.Extensibility/Data/ILibraryContext.cs
@@ -2,15 +2,15 @@
 
 namespace WixToolset.Extensibility.Data
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading;
     using WixToolset.Data;
-    using WixToolset.Extensibility.Services;
 
 #pragma warning disable 1591 // TODO: add documentation
     public interface ILibraryContext
     {
-        IWixToolsetServiceProvider ServiceProvider { get; }
+        IServiceProvider ServiceProvider { get; }
 
         bool BindFiles { get; set; }
 

--- a/src/WixToolset.Extensibility/Data/ILinkContext.cs
+++ b/src/WixToolset.Extensibility/Data/ILinkContext.cs
@@ -2,15 +2,15 @@
 
 namespace WixToolset.Extensibility.Data
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading;
     using WixToolset.Data;
-    using WixToolset.Extensibility.Services;
 
 #pragma warning disable 1591 // TODO: add documentation
     public interface ILinkContext
     {
-        IWixToolsetServiceProvider ServiceProvider { get; }
+        IServiceProvider ServiceProvider { get; }
 
         IEnumerable<ILinkerExtension> Extensions { get; set; }
 

--- a/src/WixToolset.Extensibility/Data/IPreprocessContext.cs
+++ b/src/WixToolset.Extensibility/Data/IPreprocessContext.cs
@@ -2,15 +2,15 @@
 
 namespace WixToolset.Extensibility.Data
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading;
     using WixToolset.Data;
-    using WixToolset.Extensibility.Services;
 
 #pragma warning disable 1591 // TODO: add documentation
     public interface IPreprocessContext
     {
-        IWixToolsetServiceProvider ServiceProvider { get; }
+        IServiceProvider ServiceProvider { get; }
 
         IEnumerable<IPreprocessorExtension> Extensions { get; set; }
 

--- a/src/WixToolset.Extensibility/Data/IResolveContext.cs
+++ b/src/WixToolset.Extensibility/Data/IResolveContext.cs
@@ -2,15 +2,15 @@
 
 namespace WixToolset.Extensibility.Data
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading;
     using WixToolset.Data;
-    using WixToolset.Extensibility.Services;
 
 #pragma warning disable 1591 // TODO: add documentation
     public interface IResolveContext
     {
-        IWixToolsetServiceProvider ServiceProvider { get; }
+        IServiceProvider ServiceProvider { get; }
 
         IEnumerable<IBindPath> BindPaths { get; set; }
 

--- a/src/WixToolset.Extensibility/Data/IUnbindContext.cs
+++ b/src/WixToolset.Extensibility/Data/IUnbindContext.cs
@@ -3,12 +3,11 @@
 namespace WixToolset.Extensibility.Data
 {
     using System;
-    using WixToolset.Extensibility.Services;
 
 #pragma warning disable 1591 // TODO: add documentation
     public interface IUnbindContext
     {
-        IWixToolsetServiceProvider ServiceProvider { get; }
+        IServiceProvider ServiceProvider { get; }
 
         string ExportBasePath { get; set; }
 

--- a/src/WixToolset.Extensibility/Services/IWixtoolsetCoreServiceProvider.cs
+++ b/src/WixToolset.Extensibility/Services/IWixtoolsetCoreServiceProvider.cs
@@ -8,7 +8,7 @@ namespace WixToolset.Extensibility.Services
     /// <summary>
     /// The core of the service provider used to add services to the service provider.
     /// </summary>
-    public interface IWixToolsetCoreServiceProvider : IWixToolsetServiceProvider
+    public interface IWixToolsetCoreServiceProvider : IServiceProvider
     {
         /// <summary>
         /// Adds a service to the service locator.

--- a/src/WixToolset.Extensibility/Services/ServiceProviderExtensions.cs
+++ b/src/WixToolset.Extensibility/Services/ServiceProviderExtensions.cs
@@ -5,30 +5,44 @@ namespace WixToolset.Extensibility.Services
     using System;
 
     /// <summary>
-    /// Service provider.
+    /// Service provider extensions.
     /// </summary>
-    public interface IWixToolsetServiceProvider : IServiceProvider
+    public static class ServiceProviderExtensions
     {
         /// <summary>
         /// Gets a service from the service provider.
         /// </summary>
         /// <typeparam name="T">Type of service to get.</typeparam>
-        T GetService<T>() where T : class;
+        /// <param name="provider">Service provider.</param>
+        public static T GetService<T>(this IServiceProvider provider) where T : class
+        {
+            return provider.GetService(typeof(T)) as T;
+        }
 
         /// <summary>
         /// Gets a service from the service provider.
         /// </summary>
+        /// <param name="provider">Service provider.</param>
         /// <param name="serviceType">Type of service to get.</param>
         /// <param name="service">Retrieved service.</param>
         /// <returns>True if the service was found, otherwise false</returns>
-        bool TryGetService(Type serviceType, out object service);
+        public static bool TryGetService(this IServiceProvider provider, Type serviceType, out object service)
+        {
+            service = provider.GetService(serviceType);
+            return service != null;
+        }
 
         /// <summary>
         /// Gets a service from the service provider.
         /// </summary>
         /// <typeparam name="T">Type of service to get.</typeparam>
+        /// <param name="provider">Service provider.</param>
         /// <param name="service">Retrieved service.</param>
         /// <returns>True if the service was found, otherwise false</returns>
-        bool TryGetService<T>(out T service) where T : class;
+        public static bool TryGetService<T>(this IServiceProvider provider, out T service) where T : class
+        {
+            service = provider.GetService(typeof(T)) as T;
+            return service != null;
+        }
     }
 }


### PR DESCRIPTION
There are several helpful methods for getting services out of an
IServiceProvider. Instead of introducing a custom interface to inject
those methods into the inheritance tree, this change uses extension
methods to add the helper methods and reduce the number of custom
interfaces.